### PR TITLE
Make sample working with Spring Cloud Stream 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,10 @@ ext {
 }
 
 dependencies {
-	compile('org.springframework.boot:spring-boot-starter-integration')
 	compile('org.springframework.boot:spring-boot-starter-web')
-	compile('org.apache.kafka:kafka-streams:1.0.1')
-	compile('org.springframework.cloud:spring-cloud-stream')
 	compile('org.springframework.cloud:spring-cloud-starter-stream-kafka')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
-	testCompile('org.springframework.cloud:spring-cloud-stream-test-support')
+	testCompile('org.springframework.kafka:spring-kafka-test')
 }
 
 dependencyManagement {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,20 +4,9 @@ spring:
       bindings:
         to-uppercase-request:
           destination: to-uppercase-request
-          group: stream-to-uppercase-request
-          producer:
-            required-groups: stream-to-uppercase-request
         to-uppercase-reply:
           destination: to-uppercase-reply
-          group: gateway-to-uppercase-reply
-          producer:
-           required-groups: gateway-to-uppercase-reply
-      kafka:
-        binder:
-          brokers:
-          - 192.168.34.210:9092
-      default-binder: kafka
-
-          
-server:
-  port: 8080
+        input:
+          destination: to-uppercase-request
+        output:
+          destination: to-uppercase-reply

--- a/src/test/java/com/example/restgateway/RestGatewayApplicationTests.java
+++ b/src/test/java/com/example/restgateway/RestGatewayApplicationTests.java
@@ -1,16 +1,38 @@
 package com.example.restgateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class RestGatewayApplicationTests {
 
+	@ClassRule
+	public static KafkaEmbedded kafkaEmbedded = new KafkaEmbedded(1, true);
+
+	@Autowired
+	private TestRestTemplate testRestTemplate;
+
+	@BeforeClass
+	public static void setup() {
+		System.setProperty("spring.kafka.bootstrap-servers", kafkaEmbedded.getBrokersAsString());
+	}
+
 	@Test
-	public void contextLoads() {
+	public void testSpringCloudStreamGateway() {
+		assertThat(this.testRestTemplate.getForObject("/string/{string}", String.class, "foo")).isEqualTo("FOO");
+		assertThat(this.testRestTemplate.getForObject("/string/{string}", String.class, "bar")).isEqualTo("BAR");
+		assertThat(this.testRestTemplate.getForObject("/string/{string}", String.class, "baz")).isEqualTo("BAZ");
 	}
 
 }


### PR DESCRIPTION
* Add `Processor` binding for independent `input` and `output` channels.
This way the `TO_UPPERCASE_REPLY` channel doesn't clash with one more
subscriber for round-robin distribution
* The same is applied for the `TO_UPPERCASE_REQUEST`
* Add bindings for `input` and `output` for respective destinations
* Remove `spring-cloud-stream-test-support` to let to test really against
Binder for Apache Kafka
* Add `spring-kafka-test` for testing against Embedded Kafka
* Remove redundant dependencies which are polled transitively
* Add full integration test to demonstrate how things work
* Add a `Converter<byte[], String>` bean to let to convert reply `byte[]`
to the expected return `String`.
Starting with version `2.0`, Spring Cloud String doesn't convert `byte[]`
payload unconditionally if we don't have an explicit POJO method signature